### PR TITLE
Add stylesheet support for main.html

### DIFF
--- a/webalchemy/main.html
+++ b/webalchemy/main.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    --> stylesheets
     --> include
     --> meta
 </head>

--- a/webalchemy/mainhtml.py
+++ b/webalchemy/mainhtml.py
@@ -24,6 +24,10 @@ class HtmlWriter:
         for attr, value in attributes:
             self.write(' ' + attr + '="' + value + '"')
         self.writeline('>')
+        
+    def write_stylesheet_tag(self, source):
+        line = '<link rel="stylesheet" href="' + source + '">'
+        self.writeline(line)
 
     def include(self, file_path):
         with open(file_path, 'r') as f:
@@ -81,6 +85,11 @@ def generate_main_html_for_server(app, ws_explicit_route, port, host, ssl):
             if hasattr(app, 'meta'):
                 for m in app.meta:
                     writer.write_meta_tag(m.items())
+            return
+        if tag == 'stylesheets':
+            if hasattr(app, 'stylesheets'):
+                for s in app.stylesheets:
+                    writer.write_stylesheet_tag(s)
             return
         writer.include(os.path.join(basedir, tag))
 


### PR DESCRIPTION
This allows to add stylesheets the same way as including javascript source files:

Ex:

``` python
class HellowWorldApp:

    stylesheets = ['http://code.jquery.com/mobile/1.4.0/jquery.mobile-1.4.0.min.css']

    include = ['http://code.jquery.com/jquery-1.10.2.min.js',
               'http://code.jquery.com/mobile/1.4.0/jquery.mobile-1.4.0.min.js']
```

It is working as expected, as can be seen in the browser:

``` html
<!DOCTYPE html>
<html class="ui-mobile">
   <head>
       <base href="http://127.0.0.1:8080/"></base>
       <link href="http://code.jquery.com/mobile/1.4.0/jquery.mobile-1.4.0.min.css" rel="stylesheet"></link>
       <script src="http://code.jquery.com/jquery-1.10.2.min.js" type="text/javascript"></script>
       <script src="http://code.jquery.com/mobile/1.4.0/jquery.mobile-1.4.0.min.js" type="text/javascript"></script>
```
