### PR TITLE
Add jquerymobile example

### DIFF
--- a/examples/jquerymobile/jquerymobile_example.html
+++ b/examples/jquerymobile/jquerymobile_example.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    --> stylesheets
+    --> include
+    --> meta
+</head>
+<body onload="init_communication()">
+    <!-- Create a jquery mobile page with header/footer and main area. -->
+    <div id="mypage" data-role="page">
+        <div id="header" data-role="header">Header</div>
+        <div id="main" data-role="main"></div>
+        <div id="footer" data-role="footer" data-position="fixed">Footer</div>
+    </div>
+</body>
+<script>
+	// the following files will be inserted here
+	// this is good to serve via a websocket. Can be removed
+	// if app is to be frozen
+
+	--> js/reconnecting_ws.js
+	--> js/cookie.js
+	--> js/vendor.js
+	--> js/comm.js
+	--> js/reconnection_overlay.js
+	--> js/classy.js
+    --> js/weba.js
+
+	// the following is good for freezing the app
+
+	--> websocket
+</script>
+</html> 
+
+
+

--- a/examples/jquerymobile/jquerymobile_example.py
+++ b/examples/jquerymobile/jquerymobile_example.py
@@ -1,0 +1,26 @@
+from webalchemy import server
+
+class JQueryMobileExample:
+
+    # Include the jQuery mobile stylesheet and the jQuery/jQuery mobile scripts
+    stylesheets = ['http://code.jquery.com/mobile/1.4.0/jquery.mobile-1.4.0.min.css']
+    include = ['http://code.jquery.com/jquery-1.10.2.min.js',
+               'http://code.jquery.com/mobile/1.4.0/jquery.mobile-1.4.0.min.js']
+               
+    # Use the modified html
+    main_html_file_path = "jquerymobile_example.html"
+
+    def initialize(self, **kwargs):
+        self.rdoc = kwargs['remote_document']
+        # Grab the main <div> from the html document and inject some elements
+        self.main = self.rdoc.getElementById('main')
+        self.main.element(h1="Main content")
+        self.main.element(button="A button")
+        # Force jQuery to redraw (enhance) the document
+        self.rdoc.JS('jQuery(#{self.main}).trigger("create")')
+
+
+if __name__ == '__main__':
+    # this import is necessary because of the live editing. Everything else works OK without it
+    from jquerymobile_example import JQueryMobileExample
+    server.run(JQueryMobileExample)


### PR DESCRIPTION
This adds an example to the examples folder which shows how to:
- handle jquery mobile dynamically using webalchemy
- call javascript code (to redraw jquerymobile widgets)
- use other main.html files
